### PR TITLE
Fix edit acceptance test

### DIFF
--- a/app/templates/reminders/reminder/edit.hbs
+++ b/app/templates/reminders/reminder/edit.hbs
@@ -1,5 +1,5 @@
 <div class='add-new-reminder'>
-  {{input type='text' value=model.title placeholder='Enter a title'}}
+  {{input class="title" type='text' value=model.title placeholder='Enter a title'}}
   {{input type='text' value=model.body placeholder='Enter a body'}}
   {{input class="date" type='date' value=model.date placeholder='Enter a date'}}
     <button class="save-button" {{action "edit" model}}>Save</button/>

--- a/tests/acceptance/edit-test.js
+++ b/tests/acceptance/edit-test.js
@@ -30,29 +30,18 @@ test('redirects to reminder when save is clicked', function(assert) {
 });
 
 test('edits title of reminder', function(assert) {
-  server.createList('reminder', 0);
+  server.createList('reminder', 1);
 
-  visit('/reminders/new');
-  fillIn('input:first', 'My');
-  click('.submit-button');
-
-  andThen(function() {
-    assert.equal(Ember.$('.reminder-item').length, 1);
-  });
-
-  click('.reminder-item:first');
+  visit('/reminders');
+  click('.reminder-item');
   click('.edit-button');
 
-  andThen(function() {
-    assert.equal(currentURL(), '/reminders/1/edit');
-  });
-
-  fillIn('input:first', '').then(function() {
+  fillIn('.title', 'Hey My').then(function() {
     click('.save-button');
   });
 
   andThen(function() {
     assert.equal(currentURL(), '/reminders/1');
-    assert.equal(Ember.$('input:first').text(), '');
+    assert.equal(Ember.$('.active-title').text().trim(), 'Hey My');
   });
 });


### PR DESCRIPTION
@Tman22 @martensonbj 
Per Taylor's request
Deleted redundant code in test
Changed assertion test to reflect edit on reminder

## Purpose
Make the acceptance test for edit more verbose and test the edit functionality. 

## Approach
Deleted redundant code in the test. Added a class to the title edit field. Assert that once filledIn, the text in the title will match that edited.  

### Test coverage 
Acceptance test for edit now reflects changes requested by Taylor.  Filling in the editable title and asserting that it matches. 